### PR TITLE
Order candidates, add precision and timestamp; add precinct scraping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ pip install -r requirements.txt
 
 ## Running the scraper
 
-First, navigate into the directory containing the scraper code and activate your virtual environment. If you just finished setup, above, you can skip this step!
+Whether you want to scrape the summary file or precinct results, you first need to navigate into the directory containing the scraper code and activate your virtual environment. If you just finished setup, above, you can skip this step!
 
 ```bash
 cd ~/Desktop/block-club-election-night
 source ~/.virtualenvs/elections/bin/activate
 ```
 
-Run the scraper:
+### Scraping the summary file
+
+Run the summary file scraper like this:
 
 ```bash
 python3 -m election_night.get_results
@@ -59,9 +61,28 @@ python3 -m election_night.get_results
 You should see something like this in your terminal:
 
 ```
-OrderedDict([('contest_code', 0), ('race_name', 'Totals'), ('precincts_total', 1291), ('precincts_reporting', 1), ('vote_for', 1)])
+Getting summary results from https://chicagoelections.gov/results/ap/SummaryExport.txt! 🎉
 ```
 
 This indicates the scrape ran successfully!
 
 You can view the output in the `results/` folder. Output files are grouped in a sub-folder named for the date and time you ran the scrape.
+
+### Scraping precinct-level results
+
+Late on Election Night and into the following day, the Board of Elections stops updating the
+summary file in favor of precinct-level results. You can run the precinct scraper like this:
+
+```bash
+python -m election_night.get_results --precinct
+```
+
+You should see something like this in your terminal:
+
+```
+Getting precinct results for 2023 Municipal Runoffs - 4/4/23! 🎉
+```
+
+Note that scraping precinct results takes about a minute to run, since the pages are slow to load.
+
+As before, when the scrape completes, you can view the output in the `results/` folder. Output files are grouped in a sub-folder named for the date and time you ran the scrape.

--- a/election_night/get_results.py
+++ b/election_night/get_results.py
@@ -99,7 +99,6 @@ class SummaryReporter(Reporter):
     def get_results(self):
         for race_obj in self.client.races:
             if race_obj.name == "Totals":
-                print(race_obj.serialize())
                 continue
 
             race_name = re.sub(r"(Council Member,|Alderperson|Chicago Police Department)\s", "", race_obj.name)
@@ -174,12 +173,14 @@ if __name__ == "__main__":
         client.fetch()
 
         if len(client.races) == 1:
-            print(f"No results at {summary_url} yet. Please try again after 7 p.m. on Election Night. 🗳")
+            print(
+                f"No results at {summary_url} yet. If it's not yet 7 p.m. on Election Night, "
+                "please try again later.  🗳 Otherwise, try running this command: "
+                "python -m election_night.get_results --precinct")
             sys.exit()
 
         else:
             print(f"Getting summary results from {summary_url}! 🎉")
 
         reporter = SummaryReporter(client)
-
         reporter.run()

--- a/election_night/get_results.py
+++ b/election_night/get_results.py
@@ -27,10 +27,10 @@ class Reporter(object):
         os.mkdir(self.output_directory)
 
     def get_results(self):
-        yield race, (results)
+        raise NotImplementedError
 
     def parse_result(self):
-        return record
+        raise NotImplementedError
 
     def write_report(self, race_name, results):
         with open(os.path.join(self.output_directory, f"{race_name}.csv"), "w") as output_file:
@@ -58,7 +58,6 @@ class Reporter(object):
 
             writer.writerow(final_row)
 
-
     def run(self):
         for race_name, race_obj, candidates in self.get_results():
             results = [
@@ -66,7 +65,6 @@ class Reporter(object):
             ]
 
             self.write_report(race_name, results)
-
 
 
 class PrecinctReporter(Reporter):
@@ -94,7 +92,6 @@ class PrecinctReporter(Reporter):
             "Precincts Reporting": sum(1 for p, p_data in race_obj.precincts.items() if p_data["Votes"] > 0),
             "Precincts Total": len(race_obj.precincts),
         }
-
 
 
 class SummaryReporter(Reporter):

--- a/election_night/get_results.py
+++ b/election_night/get_results.py
@@ -4,6 +4,7 @@ import os
 import re
 
 from chi_elections import SummaryClient
+from chi_elections.precincts import elections as PrecinctClient
 
 if __name__ == "__main__":
     import argparse
@@ -18,23 +19,19 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--precinct",
+        help="Pass this flag to scrape and aggregate precinct results",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--election",
+        help="If passing precinct, specify which election to scrape results from. Default: 2023 Municipal Runoffs - 4/4/23",
+        default="2023 Municipal Runoffs - 4/4/23"
+    )
 
     options = parser.parse_args()
-
-    if options.test:
-        summary_url = "https://chicagoelections.gov/results/ap/SummaryExport.txt"
-    else:
-        summary_url = "https://chicagoelections.gov/ap/SummaryExport.txt"
-
-    client = SummaryClient(url=summary_url)
-    client.fetch()
-
-    if len(client.races) == 1:
-        print(f"No results at {summary_url} yet. Please try again after 7 p.m. on Election Night. 🗳")
-        sys.exit()
-
-    else:
-        print(f"Getting results from {summary_url}! 🎉")
 
     output_directory = os.path.join(
         os.getcwd(),
@@ -46,47 +43,31 @@ if __name__ == "__main__":
 
     last_updated = f"Last updated at {datetime.datetime.now().strftime('%-I:%M %p on %b %-d, %Y')}"
 
-    police_district_results = []
-    referendum_results = []
+    if options.precinct:
+        print(f"Getting precinct results for {options.election}! 🎉")
 
-    for race in client.races:
-        if race.name == "Totals":
-            print(race.serialize())
-            continue
+        election = PrecinctClient()[options.election]
 
-        race_name = re.sub(r"(Council Member,|Alderperson|Chicago Police Department)\s", "", race.name)
+        for race_name, race_obj in election.races.items():
+            race_results = []
 
-        if race.reporting_unit_name == "POLICE":
-            race_name = f"{race_name} Council"
+            race_name = race_name.replace("Alderperson ", "").strip()
 
-        race_results = []
+            for k, v in race_obj.total.items():
+                if k == "Votes":
+                    continue
 
-        for candidate in race.candidates:
-            if race.reporting_unit_name != "SPECIAL REFERENDUM":
-                choice_name = candidate.full_name.title()
+                row = {
+                    "Race Name": race_name,
+                    "Candidate": k if k == "CB" else k.title(),
+                    "Votes Total": v,
+                    "Votes Percent": round(v / (race_obj.total["Votes"] or 1) * 100, 2),
+                    "Precincts Reporting": sum(1 for p, p_data in race_obj.precincts.items() if p_data["Votes"] > 0),
+                    "Precincts Total": len(race_obj.precincts),
+                }
 
-                if choice_name == "Cb Johnson":
-                    choice_name = "CB Johnson"
-            else:
-                choice_name = candidate.full_name
-
-            row = {
-                "Race Name": race_name,
-                "Candidate": choice_name,
-                "Votes Total": candidate.vote_total,
-                "Votes Percent": round(candidate.vote_total / (race.total_ballots_cast or 1) * 100, 2),
-                "Precincts Reporting": race.precincts_reporting,
-                "Precincts Total": race.precincts_total,
-            }
-
-            if race.reporting_unit_name == "POLICE":
-                police_district_results.append(row)
-            elif race.reporting_unit_name == "SPECIAL REFERENDUM":
-                referendum_results.append(row)
-            else:
                 race_results.append(row)
 
-        if race.reporting_unit_name not in ("POLICE", "SPECIAL REFERENDUM"):
             with open(os.path.join(output_directory, f"{race_name}.csv"), "w") as output_file:
                 writer = csv.DictWriter(
                     output_file,
@@ -112,20 +93,102 @@ if __name__ == "__main__":
 
                 writer.writerow(final_row)
 
+    else:
+        if options.test:
+            summary_url = "https://chicagoelections.gov/results/ap/SummaryExport.txt"
+        else:
+            summary_url = "https://chicagoelections.gov/ap/SummaryExport.txt"
 
-    for file, contents, first_column in (
-        ("Police Councils.csv", police_district_results, "District"),
-        ("Misc.csv", referendum_results, "Question")
-    ):
-        with open(os.path.join(output_directory, file), "w") as output_file:
-            writer = csv.writer(output_file)
-            writer.writerow([
-                first_column,
-                "Candidate",
-                "Votes Total",
-                "Votes Percent",
-                "Precincts Reporting",
-                "Precincts Total"
-            ])
-            writer.writerows(row.values() for row in contents)
-            writer.writerow(["", "", "", "", "", last_updated])
+        client = SummaryClient(url=summary_url)
+        client.fetch()
+
+        if len(client.races) == 1:
+            print(f"No results at {summary_url} yet. Please try again after 7 p.m. on Election Night. 🗳")
+            sys.exit()
+
+        else:
+            print(f"Getting summary results from {summary_url}! 🎉")
+
+        police_district_results = []
+        referendum_results = []
+
+        for race in client.races:
+            if race.name == "Totals":
+                print(race.serialize())
+                continue
+
+            race_name = re.sub(r"(Council Member,|Alderperson|Chicago Police Department)\s", "", race.name)
+
+            if race.reporting_unit_name == "POLICE":
+                race_name = f"{race_name} Council"
+
+            race_results = []
+
+            for candidate in race.candidates:
+                if race.reporting_unit_name != "SPECIAL REFERENDUM":
+                    choice_name = candidate.full_name.title()
+
+                    if choice_name == "Cb Johnson":
+                        choice_name = "CB Johnson"
+                else:
+                    choice_name = candidate.full_name
+
+                row = {
+                    "Race Name": race_name,
+                    "Candidate": choice_name,
+                    "Votes Total": candidate.vote_total,
+                    "Votes Percent": round(candidate.vote_total / (race.total_ballots_cast or 1) * 100, 2),
+                    "Precincts Reporting": race.precincts_reporting,
+                    "Precincts Total": race.precincts_total,
+                }
+
+                if race.reporting_unit_name == "POLICE":
+                    police_district_results.append(row)
+                elif race.reporting_unit_name == "SPECIAL REFERENDUM":
+                    referendum_results.append(row)
+                else:
+                    race_results.append(row)
+
+            if race.reporting_unit_name not in ("POLICE", "SPECIAL REFERENDUM"):
+                with open(os.path.join(output_directory, f"{race_name}.csv"), "w") as output_file:
+                    writer = csv.DictWriter(
+                        output_file,
+                        fieldnames=["Candidate", "Votes Total", "Votes Percent"],
+                        extrasaction="ignore"
+                    )
+
+                    sorted_results = reversed(
+                        sorted(race_results, key=lambda x: x["Votes Percent"])
+                    )
+
+                    writer.writeheader()
+                    writer.writerows(sorted_results)
+
+                    precincts_reporting = race_results[0]["Precincts Reporting"]
+                    precincts_total = race_results[0]["Precincts Total"]
+
+                    final_row = {
+                        "Candidate": f"{precincts_reporting} of {precincts_total} precincts reporting",
+                        "Votes Total": "",
+                        "Votes Percent": last_updated,
+                    }
+
+                    writer.writerow(final_row)
+
+
+        for file, contents, first_column in (
+            ("Police Councils.csv", police_district_results, "District"),
+            ("Misc.csv", referendum_results, "Question")
+        ):
+            with open(os.path.join(output_directory, file), "w") as output_file:
+                writer = csv.writer(output_file)
+                writer.writerow([
+                    first_column,
+                    "Candidate",
+                    "Votes Total",
+                    "Votes Percent",
+                    "Precincts Reporting",
+                    "Precincts Total"
+                ])
+                writer.writerows(row.values() for row in contents)
+                writer.writerow(["", "", "", "", "", last_updated])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datamade/python-chicago-elections.git@hcg/new-file-layout
+git+https://github.com/datamade/python-chicago-elections.git@hcg/precinct-results


### PR DESCRIPTION
# Description

See title! N.b., the precinct scrape takes about a minute, as those pages are slow to load.

## Testing instructions

- Run `python -m election_night.get_results --precinct --election="2023 Municipal General - 2/28/2023"` and confirm that results are ordered, percentages have two decimal points, the timestamp is added to all files, and spot check that results match those reported for the February General Election on the BoE website: https://chicagoelections.gov/en/election-results.asp?election=241&race=11
- Run `python -m election_night.get_results --test` and confirm you see results, all 0s, for the runoff
- Run `python -m election_night.get_results --precinct` and confirm you see results, all 0s, for the runoff